### PR TITLE
chore: Update DEGREE_BITS_RANGE

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-07-20
+          toolchain: nightly-2024-12-05
           override: true
       - run: rustup component add rustfmt
       - run: cargo fmt --all -- --check
@@ -57,7 +57,7 @@ jobs:
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: nightly-2024-07-20
+          toolchain: nightly-2024-12-05
           override: true
       - name: Install Dependencies
         run: sudo apt install protobuf-compiler

--- a/sdk/src/local/util.rs
+++ b/sdk/src/local/util.rs
@@ -16,8 +16,20 @@ use zkm_prover::cpu::kernel::assembler::segment_kernel;
 use zkm_prover::fixed_recursive_verifier::AllRecursiveCircuits;
 use zkm_prover::generation::state::{AssumptionReceipts, Receipt};
 
-const DEGREE_BITS_RANGE: [Range<usize>; 8] =
-    [10..21, 12..22, 11..21, 8..21, 6..21, 6..21, 6..21, 13..23];
+const DEGREE_BITS_RANGE: [Range<usize>; 12] = [
+    10..21,
+    12..22,
+    11..21,
+    8..21,
+    6..10,
+    6..10,
+    6..16,
+    6..16,
+    6..16,
+    6..16,
+    6..21,
+    13..23,
+];
 
 const D: usize = 2;
 type C = PoseidonGoldilocksConfig;


### PR DESCRIPTION
After SHA256 precompile was introduced in [PR 222](https://github.com/zkMIPS/zkm/pull/222), the DEGREE_BITS_RANGE value [was changed](https://github.com/zkMIPS/zkm/pull/222/files#diff-7cd1d42c2968eef2200e9a29030dfb94d251000e0d23f1754f15831df428ca9d) to the following:

```rust
const DEGREE_BITS_RANGE: [Range<usize>; 12] = [
    10..21,
    12..22,
    11..21,
    8..21,
    6..10,
    6..10,
    6..16,
    6..16,
    6..16,
    6..16,
    6..21,
    13..23,
];
```

The SDK, however, still uses the old value and fails to compile.
This PR updates the corresponding constant in the SDK.